### PR TITLE
Bump grocer version to support updated UI elements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     python_requires=">=3.6",
     install_requires=[
         "twilio",
-        "grocer @ git+https://git@github.com/itsjohnward/grocer@v0.2.0#egg=grocer",
+        "grocer @ git+https://git@github.com/itsjohnward/grocer@v0.2.1#egg=grocer",
     ],
     # root must be current directory
     # otherwise, use_scm_version = {"root": path, "relative_to": __file__}


### PR DESCRIPTION
See https://github.com/itsjohnward/grocer/pull/18 for more info on what updates there have been to the instacart site since v0.2.0 was released.